### PR TITLE
patch: Use width: inherit instead of width: 100% to work with the maximize plugin

### DIFF
--- a/ck.sh
+++ b/ck.sh
@@ -59,6 +59,8 @@ case "$COMMAND" in
 
 		case $yn in
 			[Yy]*)
+				cd ckeditor-dev
+
 				if [ -n "$DEBUG" ]; then
 					dev/builder/build.sh --build-config ../../../build-config.js \
 						--leave-css-unminified --leave-js-unminified
@@ -82,6 +84,7 @@ case "$COMMAND" in
 				echo
 				echo "Aborting."
 				echo
+				exit
 		esac
 		;;
 
@@ -230,6 +233,7 @@ case "$COMMAND" in
 				echo
 				echo "Aborting."
 				echo
+				exit
 				;;
 		esac
 		;;
@@ -288,6 +292,7 @@ case "$COMMAND" in
 				echo
 				echo "Aborting."
 				echo
+				exit
 				;;
 		esac
 		;;

--- a/patches/0001-patch-LPS-89596-Changed-position-of-drag-icon-for-IE.patch
+++ b/patches/0001-patch-LPS-89596-Changed-position-of-drag-icon-for-IE.patch
@@ -1,17 +1,17 @@
-From e150c14e438d6cc80da8d92eeabed67f9e5c98a0 Mon Sep 17 00:00:00 2001
+From d2e02df01e644484b40516526773a5954dddcdb1 Mon Sep 17 00:00:00 2001
 From: Julien Castelain <julien.castelain@liferay.com>
 Date: Tue, 14 May 2019 10:47:25 +0200
-Subject: [PATCH] patch: LPS-89596 Changed position of drag icon for IE.
+Subject: [PATCH 1/2] patch: LPS-89596 Changed position of drag icon for IE.
 
 ---
  plugins/widget/plugin.js | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/plugins/widget/plugin.js b/plugins/widget/plugin.js
-index d8660d4a3..9f0843fa1 100644
+index f87fbf69f..e9665862c 100644
 --- a/plugins/widget/plugin.js
 +++ b/plugins/widget/plugin.js
-@@ -1525,6 +1525,10 @@ ﻿/**
+@@ -1525,6 +1525,10 @@
  					y: domElement.offsetTop - DRAG_HANDLER_SIZE
  				};
  
@@ -23,5 +23,5 @@ index d8660d4a3..9f0843fa1 100644
  				return;
  
 -- 
-2.21.0
+2.19.1.windows.1
 

--- a/patches/0002-LPS-95472-Use-width-inherit-instead-of-width-100-to-.patch
+++ b/patches/0002-LPS-95472-Use-width-inherit-instead-of-width-100-to-.patch
@@ -1,0 +1,26 @@
+From 4fd3f0b454a6db69c0ba4de2a8316483df1c6271 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Roland=20P=C3=A1kai?= <roland.pakai@liferay.com>
+Date: Tue, 21 May 2019 09:38:15 +0200
+Subject: [PATCH 2/2] LPS-95472 Use width: inherit instead of width: 100% to
+ work with the maximize plugin
+
+---
+ plugins/dialog/plugin.js | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/dialog/plugin.js b/plugins/dialog/plugin.js
+index be0eecd6d..d9e82ff8b 100644
+--- a/plugins/dialog/plugin.js
++++ b/plugins/dialog/plugin.js
+@@ -1134,7 +1134,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
+ 					children: contents.elements,
+ 					expand: !!contents.expand,
+ 					padding: contents.padding,
+-					style: contents.style || 'width: 100%;'
++					style: contents.style || 'width: inherit;'
+ 				}, pageHtml );
+ 
+ 			var contentMap = this._.contents[ contents.id ] = {},
+-- 
+2.19.1.windows.1
+


### PR DESCRIPTION
Hi Greg,

Please check my patch.

https://issues.liferay.com/browse/LPS-95472